### PR TITLE
store address now link to google maps

### DIFF
--- a/src/AppBundle/Resources/views/Store/store.html.twig
+++ b/src/AppBundle/Resources/views/Store/store.html.twig
@@ -13,11 +13,13 @@
             </div>
             <div class="list-group">
                 {% if store.address %}
-                    <p class="list-group-item">
+                    {% set full_address %}{{ store.address }} {{ store.city }}, {{ store.state }} {{ store.zip }}{% endset %}
+
+                    <a href="http://maps.google.com/?q={{ full_address|url_encode }}" target="_new" title="See in Google Maps" class="list-group-item">
                         <span class="badge"><span class="glyphicon glyphicon-home" aria-hidden="true"></span></span>
                         {{ store.address }}<br/>
                         {{ store.city }}, {{ store.state }} {{ store.zip }}
-                    </p>
+                    </a>
                 {% endif %}
                 {% if store.phone %}
                     <p class="list-group-item">


### PR DESCRIPTION
Link store address to Google Maps to make it easier for users to find directions to the store.
