### PR TITLE
fix redirect issue on ios

### DIFF
--- a/src/AppBundle/Resources/views/Challenge/index.html.twig
+++ b/src/AppBundle/Resources/views/Challenge/index.html.twig
@@ -48,7 +48,7 @@
     {% endjavascripts %}
     <script>
     var completeUrl = "{{ path('complete_challenge', {'id': challenge.id }) }}",
-        successUrl = "{{ path('challenges') }}",
+        successUrl = window.location.origin + "{{ path('challenges') }}",
         players = [];
 
     function completeChallenge() {
@@ -70,7 +70,7 @@
             data: {players: players},
             success: function (data) {
                 console.log(data);
-                window.location.replace(successUrl);
+                window.location.assign(successUrl);
             }
         });
     }


### PR DESCRIPTION
Hoping this fixes the redirect issue in iOS.

Additionally, allowing users to use the back button to go back to Challenges that were just closed (now that they can't re-submit).

Fixes issue #13 
