### PR TITLE
fix the redirect issue in ios

### DIFF
--- a/src/AppBundle/Controller/ChallengeController.php
+++ b/src/AppBundle/Controller/ChallengeController.php
@@ -101,7 +101,6 @@ class ChallengeController extends Controller
         # Using order of POST-players, update all the players
         $repo = $em->getRepository('AppBundle:Player');
         foreach ($data as $i => $val) {
-            var_dump($val['name']);
             $player = $repo->findOneByName($val['name']);
             $prev   = $player->getRank();
 

--- a/src/AppBundle/Resources/views/Challenge/index.html.twig
+++ b/src/AppBundle/Resources/views/Challenge/index.html.twig
@@ -69,7 +69,6 @@
             method: 'POST',
             data: {players: players},
             success: function (data) {
-                console.log(data);
                 window.location.assign(successUrl);
             }
         });


### PR DESCRIPTION
Final fix for the redirect issue in iOS. Apparently having `var_dump` in your json is bad, who knew? :stuck_out_tongue_closed_eyes: 

Closes issue #16 
